### PR TITLE
OpenTracks behaves differently while pausing

### DIFF
--- a/app/src/main/java/de/storchp/opentracks/osmplugin/Constants.java
+++ b/app/src/main/java/de/storchp/opentracks/osmplugin/Constants.java
@@ -19,6 +19,13 @@ public class Constants {
 
         public static final double PAUSE_LATITUDE = 100.0;
         public static final double RESUME_LATITUDE = 200.0;
+
+        public static final String[] PROJECTION = {
+                Constants.Trackpoints._ID,
+                Constants.Trackpoints.LATITUDE,
+                Constants.Trackpoints.LONGITUDE,
+                Constants.Trackpoints.TIME
+        };
     }
 
     // Track columns
@@ -37,6 +44,23 @@ public class Constants {
         public static final String MINELEVATION = "minelevation"; // minimum elevation
         public static final String MAXELEVATION = "maxelevation"; // maximum elevation
         public static final String ELEVATIONGAIN = "elevationgain"; // elevation gain
+
+        public static final String[] PROJECTION = {
+                Constants.Track.NAME,
+                Constants.Track.DESCRIPTION,
+                Constants.Track.CATEGORY,
+                Constants.Track.STARTTIME,
+                Constants.Track.STOPTIME,
+                Constants.Track.TOTALDISTANCE,
+                Constants.Track.TOTALTIME,
+                Constants.Track.MOVINGTIME,
+                Constants.Track.AVGSPEED,
+                Constants.Track.AVGMOVINGSPEED,
+                Constants.Track.MAXSPEED,
+                Constants.Track.MINELEVATION,
+                Constants.Track.MAXELEVATION,
+                Constants.Track.ELEVATIONGAIN
+        };
     }
 
     /**

--- a/app/src/main/java/de/storchp/opentracks/osmplugin/Constants.java
+++ b/app/src/main/java/de/storchp/opentracks/osmplugin/Constants.java
@@ -18,7 +18,6 @@ public class Constants {
         public static final String TIME = "time";
 
         public static final double PAUSE_LATITUDE = 100.0;
-        public static final double RESUME_LATITUDE = 200.0;
 
         public static final String[] PROJECTION = {
                 Constants.Trackpoints._ID,
@@ -71,7 +70,7 @@ public class Constants {
      * @return true if the location is a valid location.
      */
     public static boolean isValidLocation(double latitude, double longitude) {
-        return Math.abs(latitude) <= 90 && Math.abs(longitude) <= 180;
+        return Math.abs(latitude) <= 90 && Math.abs(longitude) <= 180 && longitude != Trackpoints.PAUSE_LATITUDE;
     }
 
     public static Uri getTracksUri(ArrayList<Uri> uris) {

--- a/app/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
+++ b/app/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
@@ -429,8 +429,8 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
             Polyline polyline = newPolyline();
 
             while (cursor.moveToNext()) {
-                double latitude = Double.parseDouble(cursor.getString(cursor.getColumnIndex(Constants.Trackpoints.LATITUDE))) / 1E6;
-                double longitude = Double.parseDouble(cursor.getString(cursor.getColumnIndex(Constants.Trackpoints.LONGITUDE))) / 1E6;
+                double latitude = cursor.getInt(cursor.getColumnIndex(Constants.Trackpoints.LATITUDE)) / 1E6;
+                double longitude = cursor.getInt(cursor.getColumnIndex(Constants.Trackpoints.LONGITUDE)) / 1E6;
                 Log.d(TAG, "Got coordinates: " + latitude + " " + longitude);
 
                 if (Constants.isValidLocation(latitude, longitude)) {

--- a/app/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
+++ b/app/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
@@ -450,8 +450,8 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
             double longitude = Double.parseDouble(cursor.getString(cursor.getColumnIndex(Constants.Trackpoints.LONGITUDE))) / 1E6;
             if (!Constants.isValidLocation(latitude, longitude)) {
                 pause = latitude == Constants.Trackpoints.PAUSE_LATITUDE;
-                if (pause && !polyline.getLatLongs().isEmpty()) {
-                    layers.add(polyline);;
+                if (pause && polyline.getLatLongs().isEmpty()) {
+                    layers.add(polyline);
                     polylines.add(polyline);
                     Log.d(TAG, "Pause Trackpoint");
                 }

--- a/app/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
+++ b/app/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
@@ -409,21 +409,12 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
     }
 
     private void readTrackpoints(Uri data, boolean update) {
-        // A "projection" defines the columns that will be returned for each row
-        String[] projection =
-                {
-                        Constants.Trackpoints._ID,
-                        Constants.Trackpoints.LATITUDE,
-                        Constants.Trackpoints.LONGITUDE,
-                        Constants.Trackpoints.TIME
-                };
-
         Log.i(TAG, "Loading track from " + data);
 
         // Does a query against the table and returns a Cursor object
         final Cursor cursor = getContentResolver().query(
                 data,
-                projection,
+                Constants.Trackpoints.PROJECTION,
                 null,
                 null,
                 null);
@@ -542,32 +533,12 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
     }
 
     private void readTrack(Uri data) {
-        // A "projection" defines the columns that will be returned for each row
-        String[] projection =
-                {
-                        Constants.Track.NAME,
-                        Constants.Track.DESCRIPTION,
-                        Constants.Track.CATEGORY,
-                        Constants.Track.STARTTIME,
-                        Constants.Track.STOPTIME,
-                        Constants.Track.TOTALDISTANCE,
-                        Constants.Track.TOTALTIME,
-                        Constants.Track.MOVINGTIME,
-                        Constants.Track.AVGSPEED,
-                        Constants.Track.AVGMOVINGSPEED,
-                        Constants.Track.MAXSPEED,
-                        Constants.Track.MINELEVATION,
-                        Constants.Track.MAXELEVATION,
-                        Constants.Track.ELEVATIONGAIN
-
-                };
-
         Log.i(TAG, "Loading track from " + data);
 
         // Does a query against the table and returns a Cursor object
         final Cursor cursor = getContentResolver().query(
                 data,
-                projection,
+                Constants.Track.PROJECTION,
                 null,
                 null,
                 null);
@@ -591,11 +562,6 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
             // TODO: show data on dashboard
             Log.d(TAG, "Track: " + name + ", start: " + startTime + ", end: " + stopTime);
         }
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
     }
 
     @Override
@@ -704,7 +670,7 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
         @Override
         public boolean onMenuItemClick(MenuItem item) {
             item.setChecked(true);
-            if (item.getItemId() == R.id.default_theme) { // default theme
+            if (item.getItemId() == R.id.default_theme) {
                 baseApplication.setMapTheme(null);
             } else {
                 baseApplication.setMapTheme(new File(mapThemeDirectory, item.getTitle().toString()).getAbsolutePath());
@@ -717,6 +683,4 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
             return false;
         }
     }
-
 }
-

--- a/app/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
+++ b/app/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
@@ -417,8 +417,6 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
         }
         polylines.clear();
 
-        Polyline polyline = newPolyline();
-
         double minLat = 0;
         double maxLat = 0;
         double minLon = 0;
@@ -429,13 +427,14 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
         boolean pause = false;
 
         try (Cursor cursor = getContentResolver().query(data, Constants.Trackpoints.PROJECTION, null, null, null)) {
+            Polyline polyline = newPolyline();
+
             while (cursor.moveToNext()) {
                 double latitude = Double.parseDouble(cursor.getString(cursor.getColumnIndex(Constants.Trackpoints.LATITUDE))) / 1E6;
                 double longitude = Double.parseDouble(cursor.getString(cursor.getColumnIndex(Constants.Trackpoints.LONGITUDE))) / 1E6;
                 if (!Constants.isValidLocation(latitude, longitude)) {
                     pause = latitude == Constants.Trackpoints.PAUSE_LATITUDE;
                     if (pause && polyline.getLatLongs().isEmpty()) {
-                        layers.add(polyline);
                         polylines.add(polyline);
                         Log.d(TAG, "Pause Trackpoint");
                     }
@@ -479,9 +478,14 @@ public class MapsActivity extends AppCompatActivity implements DirectoryChooserF
                     startPos = latLong;
                 }
             }
+
+            // At last line
+            polylines.add(polyline);
         }
-        layers.add(polyline);
-        polylines.add(polyline);
+
+        for (Polyline polyline : polylines) {
+            layers.add(polyline);
+        }
 
         if (startPos != null) {
             if (startPoint == null) {


### PR DESCRIPTION
I just tested the functionality introduced for #6.
However, OpenTracks behaves differently than I expected.
In fact, only PAUSE_LATITUDE are inserted while RESUME_LATITUDE do not reach the database.
I am still trying to figure out why.

Now, the feature works as expected (and I also did some refactoring).

@pstorch Next time I will provide test data first.....
I did not check OpenTracks code before opening the issue.