### PR TITLE
Android 12 needs to declare the new HIGH_SAMPLING_RATE_SENSORS permission in Manifest.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="de.storchp.opentracks.osmplugin">
 
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
+
     <application
         android:name=".Startup"
         android:allowBackup="true"


### PR DESCRIPTION
This PR fixes #130 issue in Android 12.
More info: https://proandroiddev.com/review-of-android-12-for-developers-ea3ce9247e0